### PR TITLE
ENG-1948: Mark withTaskRetryPolicy operation as `@Sendable`

### DIFF
--- a/Sources/Merge/Intramodular/Rate-limiting & Retrying/_TaskRetryPolicy.swift
+++ b/Sources/Merge/Intramodular/Rate-limiting & Retrying/_TaskRetryPolicy.swift
@@ -47,7 +47,7 @@ public enum _TaskRetryError: Error {
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 public func withTaskRetryPolicy<Result>(
     _ retryPolicy: _TaskRetryPolicy?,
-    operation: () async throws -> Result
+    operation: @Sendable () async throws -> Result
 ) async throws -> Result {
     guard let retryPolicy else {
         return try await operation()


### PR DESCRIPTION
When using withTaskRetryPolicy with an actor isolated function/value, Swift 6 throws up the following error: `Sending 'self'-isolated value of type '() async throws -> ()' with later accesses to nonisolated context risks causing data races`